### PR TITLE
bugfix in hacking tolerance

### DIFF
--- a/best.js
+++ b/best.js
@@ -50,7 +50,7 @@ function Weight(ns, server) {
 	}
 	else
 		// If we do not have formulas, we can't properly factor in hackchance, so we lower the hacking level tolerance by half
-		if (so.requiredHackingSkill > player.skills.hacking / 2)
+		if (so.requiredHackingSkill > (player.skills.hacking / 2)+1)
 			return 0;
 
 	return weight;


### PR DESCRIPTION
Without this, the hacking tolerance causes the system to return an empty list of servers if the player hacking level is 1